### PR TITLE
Bugfix/ctv 2905 use tar 1.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## v1.2.2
+* Use latest TAR for polyfill fixes
+
 ## v1.2.1
 * Use the latest TAR to allow the use existing network_user_id if present, key map overrides
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "TruexRefApp_GoogleIMA",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1064,9 +1064,9 @@
             }
         },
         "@truex/ctv-ad-renderer": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/@truex/ctv-ad-renderer/-/ctv-ad-renderer-1.2.6.tgz",
-            "integrity": "sha512-FG4qPRDOOJWklQZQ6joCmJ/bh+6iXrLdTFckfZZ43NGxQFk9wpf4X8SAySpDyuivJI7bCCr+Ft3knadyq+rNAg==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@truex/ctv-ad-renderer/-/ctv-ad-renderer-1.2.7.tgz",
+            "integrity": "sha512-xhlx9rCxwS+78GXbNOYyosH4q2e4SCuNh/ALGZu8k07Ijr+WzQT4kscBjtWxYsCnfSDX3ZJp1sSONo8TzSBuvQ==",
             "requires": {
                 "bluebird": "^3.5.1",
                 "centralize-js": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "webpack-serve": "^1.0.4"
     },
     "dependencies": {
-        "@truex/ctv-ad-renderer": "1.2.6",
+        "@truex/ctv-ad-renderer": "1.2.7",
         "adm-zip": "^0.5.1",
         "core-js": "^3.6.4",
         "truex-shared": "https://github.com/socialvibe/truex-shared-js.git#v1.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "TruexRefApp_GoogleIMA",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "Sample app to demonstrate how to integrate Google IMA with true[X]'s CTV Web ad renderer",
     "main": "index.js",
     "public": true,


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-2905

### Description
Disable choice card lib polyfills, turns out it corrupts RegExp/split processing when run after TAR lib's polyfills have been run.

### Testing
* Run from Skyline, dynamic-tar-test.html, unit tests.

### Commit Message Subject
CTV-2905: trouble shoot crackle Funimation PS4 history.back crash

### Additional Context
n/a

### Related PRs
ic: https://github.com/socialvibe/integration_core/pull/190
TAR: https://github.com/socialvibe/TruexAdRenderer-HTML5/pull/78
Skyline: https://github.com/socialvibe/Skyline/pull/178
ref-app-ctv: https://github.com/socialvibe/truex-ctv-web-reference-app/pull/58
firetv-webview: https://github.com/socialvibe/firetv-webview-webapp/pull/41

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
