### PR TITLE
Bugfix/ctv 3207 ensure ability to skip demo ad in reference app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
     - develop
     - master
     - /^release/
-    - test
+    - /^test/
 install:
   - npm install
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## v1.5.0
+* Ensure "2" key skips fallback ad videos
+
 ## v1.4.0
 * Use latest TAR to support release/1-4-0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "TruexRefApp_GoogleIMA",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "description": "Sample app to demonstrate how to integrate Google IMA with true[X]'s CTV Web ad renderer",
     "main": "index.js",
     "public": true,

--- a/src/components/ad-break.js
+++ b/src/components/ad-break.js
@@ -28,4 +28,8 @@ export class AdBreak {
     get fallbackDuration() {
         return this.duration - this.placeHolderDuration;
     }
+
+    contains(time) {
+        return this.startTime <= time && time < this.endTime;
+    }
 }

--- a/src/components/ad-break.js
+++ b/src/components/ad-break.js
@@ -6,7 +6,7 @@
  * or else 3rd party non-truex ad videos. For completed interactive ads, the entire ad break is skipped.
  */
 export class AdBreak {
-    constructor(cuePoint, index) {
+    constructor(cuePoint, index, previousAdBreakDurations) {
         this.index = index;
         this.startTime = cuePoint.start;
         this.endTime = cuePoint.end;
@@ -15,6 +15,8 @@ export class AdBreak {
 
         // The length of the truex placeholder video.
         this.placeHolderDuration = 0;
+
+        this.contentStartTime = this.startTime - previousAdBreakDurations;
     }
 
     get duration() {

--- a/src/components/ad-break.js
+++ b/src/components/ad-break.js
@@ -6,7 +6,7 @@
  * or else 3rd party non-truex ad videos. For completed interactive ads, the entire ad break is skipped.
  */
 export class AdBreak {
-    constructor(cuePoint, index, previousAdBreakDurations) {
+    constructor(cuePoint, index) {
         this.index = index;
         this.startTime = cuePoint.start;
         this.endTime = cuePoint.end;
@@ -15,8 +15,6 @@ export class AdBreak {
 
         // The length of the truex placeholder video.
         this.placeHolderDuration = 0;
-
-        this.contentStartTime = this.startTime - previousAdBreakDurations;
     }
 
     get duration() {

--- a/src/components/interactive-ad.js
+++ b/src/components/interactive-ad.js
@@ -142,6 +142,7 @@ export class InteractiveAd {
                 if (adOverlay.parentNode) adOverlay.parentNode.removeChild(adOverlay);
                 adOverlay = null;
             }
+            videoController.showPlayer(true);
         }
 
         function resumePlayback() {
@@ -150,7 +151,7 @@ export class InteractiveAd {
                 adBreak.completed = true;
                 videoController.skipAdBreak(adBreak);
             } else {
-                videoController.resumeAdBreak();
+                videoController.resumeAdBreak(adBreak);
             }
         }
     }

--- a/src/components/interactive-ad.js
+++ b/src/components/interactive-ad.js
@@ -148,10 +148,9 @@ export class InteractiveAd {
             if (adFreePod) {
                 // The user has the ad credit, skip over the ad video.
                 adBreak.completed = true;
-                videoController.restartAfterAdBreak(adBreak);
+                videoController.skipAdBreak(adBreak);
             } else {
-                // Just restart video playback at the current fallback ad.
-                videoController.startVideoLater();
+                videoController.resumeAdBreak();
             }
         }
     }

--- a/src/components/interactive-ad.js
+++ b/src/components/interactive-ad.js
@@ -148,10 +148,11 @@ export class InteractiveAd {
             if (adFreePod) {
                 // The user has the ad credit, skip over the ad video.
                 adBreak.completed = true;
-                videoController.skipAd(adBreak);
+                videoController.skipAdBreak(adBreak);
+            } else {
+                // Just restart video playback at the current fallback ad.
+                videoController.startVideoLater();
             }
-
-            videoController.startVideoLater();
         }
     }
 }

--- a/src/components/interactive-ad.js
+++ b/src/components/interactive-ad.js
@@ -148,7 +148,7 @@ export class InteractiveAd {
             if (adFreePod) {
                 // The user has the ad credit, skip over the ad video.
                 adBreak.completed = true;
-                videoController.skipAdBreak(adBreak);
+                videoController.restartAfterAdBreak(adBreak);
             } else {
                 // Just restart video playback at the current fallback ad.
                 videoController.startVideoLater();

--- a/src/components/interactive-ad.js
+++ b/src/components/interactive-ad.js
@@ -1,9 +1,6 @@
 import uuid from 'uuid';
 import { TruexAdRenderer } from '@truex/ctv-ad-renderer';
 
-// Use a random UUID for the "opt out of tracking" advertising id that is stable for all ads in an app session.
-const optOutAdvertisingId = uuid.v4();
-
 // Exercises the True[X] Ad Renderer for interactive ads.
 export class InteractiveAd {
     constructor(vastConfigUrl, adBreak, videoController) {
@@ -18,14 +15,10 @@ export class InteractiveAd {
 
             videoController.showLoadingSpinner(true);
 
-            const nativeAdvertisingId = await getNativePlatformAdvertisingId();
-
             try {
                 videoController.pause();
 
                 const options = {
-                    userAdvertisingId: nativeAdvertisingId, // i.e. override from native side query if present
-                    fallbackAdvertisingId: optOutAdvertisingId, // random fallback to use if no user ad id is available
                     supportsUserCancelStream: true // i.e. user backing out of an ad will cancel the entire video
                 };
 
@@ -87,43 +80,6 @@ export class InteractiveAd {
                     resumePlayback();
                     break;
             }
-        }
-
-        async function getNativePlatformAdvertisingId() {
-            if (window.webApp && window.fireTvApp) {
-                return new Promise(function(resolve, reject) {
-                    window.webApp.onAdvertisingIdReady = function(advertisingId) {
-                        // consume the callback
-                        window.webApp.onAdvertisingIdReady = null;
-                        resolve(advertisingId);
-                    }
-
-                    window.fireTvApp.getAdvertisingId && window.fireTvApp.getAdvertisingId();
-                });
-            }
-
-            var advertisingId = undefined;
-
-            if (platform.isTizen) {
-                const webapis = window.webapis;
-                const adinfo = webapis && webapis.adinfo;
-                if (adinfo) {
-                    try {
-                        if (adinfo.isLATEnabled()) {
-                            console.log('tizen ad id ignored due to Limited Ad Tracking');
-                        } else {
-                            advertisingId = adinfo.getTIFA();
-                            console.log('tizen ad id: ' + advertisingId);
-                        }
-                    } catch (err) {
-                        console.warn('tizen ad id error: ' + platform.describeError(err));
-                    }
-                } else {
-                    console.warn('tizen ad id: webapis not present');
-                }
-            }
-
-            return Promise.resolve(advertisingId);
         }
 
         function handleAdError(errOrMsg) {

--- a/src/components/video-controller.js
+++ b/src/components/video-controller.js
@@ -656,7 +656,7 @@ export class VideoController {
         for (var index in this.adBreaks) {
             const adBreak = this.adBreaks[index];
             if (rawVideoTime < adBreak.startTime) break; // future ads don't affect things
-            if (adBreak.startTime <= rawVideoTime && rawVideoTime < adBreak.endTime) {
+            if (adBreak.contains(rawVideoTime)) {
                 const fallbackStart = adBreak.fallbackStartTime;
                 if (!skipAds && rawVideoTime >= fallbackStart) {
                     // Show the position within the fallback ads.

--- a/src/components/video-controller.js
+++ b/src/components/video-controller.js
@@ -370,7 +370,9 @@ export class VideoController {
         if (showControlBar === undefined) showControlBar = true; // default to showing the control bar
 
         const currTime = this.currVideoTime;
-        if (currTime == newTarget) return; // already at the target
+
+        // not needed, seems better to force the seek in stuck situations
+        //if (currTime == newTarget) return; // already at the target
 
         const video = this.video;
 

--- a/src/components/video-controller.js
+++ b/src/components/video-controller.js
@@ -302,7 +302,6 @@ export class VideoController {
 
     play() {
         const playNow = () => {
-            // don't interrupt current play invocations
             if (!this.video) return;
             console.log(`play at: ${this.timeDebugDisplay(this.currVideoTime)}`);
             const playPromise = this.video.play();

--- a/src/components/video-controller.js
+++ b/src/components/video-controller.js
@@ -487,6 +487,7 @@ export class VideoController {
         // skip a little past the end to avoid a flash of the final ad frame
         this.rawSeekTo(adBreak.endTime + 1);
         this.play();
+        this.showPlayer(true);
     }
 
     resumeAdBreak(adBreak) {

--- a/src/components/video-controller.js
+++ b/src/components/video-controller.js
@@ -140,26 +140,15 @@ export class VideoController {
         const adUI = document.createElement('div');
         this.streamManager = new StreamManager(video, adUI);
 
-        var streamEvents;
-        if (isFirstStart) {
-            // We need to load the main video url and full ad playlist.
-            streamEvents = [
-                StreamEvent.Type.LOADED,
-                StreamEvent.Type.ERROR,
-                StreamEvent.Type.CUEPOINTS_CHANGED,
-                StreamEvent.Type.STARTED,
-                StreamEvent.Type.AD_BREAK_STARTED,
-                StreamEvent.Type.AD_BREAK_ENDED
-            ];
-        } else {
-            // Restarting, so we only need to know the next ad.
-            streamEvents = [
-                StreamEvent.Type.ERROR,
-                StreamEvent.Type.STARTED,
-                StreamEvent.Type.AD_BREAK_STARTED,
-                StreamEvent.Type.AD_BREAK_ENDED
-            ];
-        }
+        const streamEvents = [
+            StreamEvent.Type.LOADED,
+            StreamEvent.Type.ERROR,
+            StreamEvent.Type.CUEPOINTS_CHANGED,
+            StreamEvent.Type.STARTED,
+            StreamEvent.Type.COMPLETE,
+            StreamEvent.Type.AD_BREAK_STARTED,
+            StreamEvent.Type.AD_BREAK_ENDED
+        ];
         this.streamManager.addEventListener(streamEvents, this.onStreamEvent, false);
 
         const streamRequest = new google.ima.dai.api.VODStreamRequest();
@@ -261,6 +250,14 @@ export class VideoController {
                 break;
             default:
                 break;
+        }
+    }
+
+    showPlayer(visible) {
+        if (visible) {
+            this.videoOwner.classList.add('show');
+        } else {
+            this.videoOwner.classList.remove('show');
         }
     }
 
@@ -500,6 +497,7 @@ export class VideoController {
         this.hideControlBar();
         this.rawSeekTo(adBreak.fallbackStartTime);
         this.play();
+        this.showPlayer(true);
     }
 
     startInteractiveAd(googleAd) {
@@ -518,6 +516,8 @@ export class VideoController {
         // So anything not an interactive ad we just let play.
         const isInteractiveAd = googleAd.getAdSystem() == 'trueX' && podInfo.getAdPosition() == 1;
         if (!isInteractiveAd) return;
+
+        this.showPlayer(false);
 
         var vastConfigUrl = googleAd.getDescription();
         vastConfigUrl = vastConfigUrl && vastConfigUrl.trim();

--- a/src/components/video-controller.js
+++ b/src/components/video-controller.js
@@ -69,6 +69,10 @@ export class VideoController {
         this.closeVideoAction = function() {}; // override as needed
     }
 
+    controlsEnabled() {
+        return this.videoStarted && this.videoOwner.classList.contains('show');
+    }
+
     showControlBar(forceTimer) {
         this.controlBarDiv.classList.add('show');
         this.isControlBarVisible = true;

--- a/src/components/video-controller.js
+++ b/src/components/video-controller.js
@@ -742,7 +742,7 @@ export class VideoController {
             this.pauseButton.classList.add('show');
         }
 
-        const durationToDisplay = adBreak ? adBreak.duration : this.getPlayingVideoDuration();
+        const durationToDisplay = adBreak ? adBreak.fallbackDuration : this.getPlayingVideoDuration();
 
         function percentage(time) {
             const result = durationToDisplay > 0 ? (time / durationToDisplay) * 100 : 0;

--- a/src/components/video-controller.js
+++ b/src/components/video-controller.js
@@ -259,8 +259,10 @@ export class VideoController {
 
     showPlayer(visible) {
         if (visible) {
+            console.log("showing player");
             this.videoOwner.classList.add('show');
         } else {
+            console.log("hiding player");
             this.videoOwner.classList.remove('show');
         }
     }

--- a/src/components/video-controller.js
+++ b/src/components/video-controller.js
@@ -577,13 +577,7 @@ export class VideoController {
             this.adMarkersDiv.removeChild(childNodes[i]);
         }
 
-        this.adBreaks = [];
-        let totalAdBreakDuration = 0;
-        cuePoints.forEach((cue, index) => {
-            const adBreak = new AdBreak(cue, index, totalAdBreakDuration);
-            this.adBreaks.push(adBreak);
-            totalAdBreakDuration += adBreak.duration;
-        });
+        this.adBreaks = cuePoints.map((cue, index) => new AdBreak(cue, index));
 
         console.log("ad breaks: " + this.adBreaks.map(adBreak => {
             return timeLabel(this.getPlayingVideoTimeAt(adBreak.startTime, true))
@@ -642,12 +636,15 @@ export class VideoController {
 
     getRawVideoTimeAt(contentVideoTime) {
         let result = contentVideoTime;
+        let previousAdBreakDurations = 0;
         for (var index in this.adBreaks) {
             const adBreak = this.adBreaks[index];
-            if (contentVideoTime < adBreak.contentStartTime) break; // future ads don't affect things
-            if (adBreak.contentStartTime < contentVideoTime) {
+            const adBreakContentStart = adBreak.startTime - previousAdBreakDurations;
+            if (contentVideoTime < adBreakContentStart) break; // future ads don't affect things
+            if (adBreakContentStart < contentVideoTime) {
                 result += adBreak.duration;
             }
+            previousAdBreakDurations += adBreak.duration;
         }
         return result;
     }

--- a/src/components/video-controller.scss
+++ b/src/components/video-controller.scss
@@ -24,6 +24,8 @@
     display: block;
   }
 
+  cursor: pointer;
+
   .play-button, .pause-button {
     vertical-align: middle;
     width: $playW;

--- a/src/main.js
+++ b/src/main.js
@@ -176,7 +176,7 @@ import { VideoController } from "./components/video-controller";
 
             if (action == inputActions.num2 || action == inputActions.rightStick) {
                 // QA helper to allow ads to be skipped.
-                videoController.restartAfterAdBreak();
+                videoController.skipAdBreak();
                 return true; // handled
             }
         });

--- a/src/main.js
+++ b/src/main.js
@@ -162,8 +162,6 @@ import { VideoController } from "./components/video-controller";
                 return;
             }
 
-            console.log('input action: ' + action);
-
             if (action == inputActions.select || action == inputActions.playPause) {
                 videoController.togglePlayPause();
                 return true; // handled

--- a/src/main.js
+++ b/src/main.js
@@ -162,6 +162,8 @@ import { VideoController } from "./components/video-controller";
                 return;
             }
 
+            console.log('input action: ' + action);
+
             if (action == inputActions.select || action == inputActions.playPause) {
                 videoController.togglePlayPause();
                 return true; // handled

--- a/src/main.js
+++ b/src/main.js
@@ -176,7 +176,7 @@ import { VideoController } from "./components/video-controller";
 
             if (action == inputActions.num2 || action == inputActions.rightStick) {
                 // QA helper to allow ads to be skipped.
-                videoController.skipAd();
+                videoController.skipAdBreak();
                 return true; // handled
             }
         });

--- a/src/main.js
+++ b/src/main.js
@@ -157,6 +157,11 @@ import { VideoController } from "./components/video-controller";
 
         // The entire page is the focus.
         setFocus(pageDiv, null, action => {
+            if (!videoController.controlsEnabled()) {
+                // Do nothing until user controls are enabled.
+                return;
+            }
+
             if (action == inputActions.select || action == inputActions.playPause) {
                 videoController.togglePlayPause();
                 return true; // handled

--- a/src/main.js
+++ b/src/main.js
@@ -176,7 +176,7 @@ import { VideoController } from "./components/video-controller";
 
             if (action == inputActions.num2 || action == inputActions.rightStick) {
                 // QA helper to allow ads to be skipped.
-                videoController.skipAdBreak();
+                videoController.restartAfterAdBreak();
                 return true; // handled
             }
         });

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -22,22 +22,25 @@ const deploy = () => {
     }
 
     console.log(`deploying to ${bucket}/${prefix}`);
-    return s3.cleanFolder(bucket, prefix)
-        .then(() => {
-            return uploadDist(bucket, prefix);
-        })
-        .then(() => {
-            console.log("invalidating cloudfront cache");
-            const pathsToInvalidate = [`/${prefix}/index.html`];
-            return awsCloudFrontInvalidate(cloudFrontDistId, pathsToInvalidate);
-        })
-        .then(() => {
-            console.log("deploy complete");
-        })
-        .catch((err) => {
-            console.error(`deploy error: ${err}`);
-            process.exit(1);
-        });
+    // Note: ensure trailing / so that only the branch folder is deleted.
+    // Otherwise, sibling folders with the same prefix are also deleted.
+    // This is due to S3 folders being just a prefix naming convention using / as a separator.
+    return s3.cleanFolder(bucket, prefix + '/')
+    .then(() => {
+        return uploadDist(bucket, prefix);
+    })
+    .then(() => {
+        console.log("invalidating cloudfront cache");
+        const pathsToInvalidate = [`/${prefix}/index.html`];
+        return awsCloudFrontInvalidate(cloudFrontDistId, pathsToInvalidate);
+    })
+    .then(() => {
+        console.log("deploy complete");
+    })
+    .catch((err) => {
+        console.error(`deploy error: ${err}`);
+        process.exit(1);
+    });
 };
 
 deploy();

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -26,21 +26,21 @@ const deploy = () => {
     // Otherwise, sibling folders with the same prefix are also deleted.
     // This is due to S3 folders being just a prefix naming convention using / as a separator.
     return s3.cleanFolder(bucket, prefix + '/')
-    .then(() => {
-        return uploadDist(bucket, prefix);
-    })
-    .then(() => {
-        console.log("invalidating cloudfront cache");
-        const pathsToInvalidate = [`/${prefix}/index.html`];
-        return awsCloudFrontInvalidate(cloudFrontDistId, pathsToInvalidate);
-    })
-    .then(() => {
-        console.log("deploy complete");
-    })
-    .catch((err) => {
-        console.error(`deploy error: ${err}`);
-        process.exit(1);
-    });
+        .then(() => {
+            return uploadDist(bucket, prefix);
+        })
+        .then(() => {
+            console.log("invalidating cloudfront cache");
+            const pathsToInvalidate = [`/${prefix}/index.html`];
+            return awsCloudFrontInvalidate(cloudFrontDistId, pathsToInvalidate);
+        })
+        .then(() => {
+            console.log("deploy complete");
+        })
+        .catch((err) => {
+            console.error(`deploy error: ${err}`);
+            process.exit(1);
+        });
 };
 
 deploy();


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-3207

### Description
* Work around HLS controller seek hangs across ad boundaries by detaching/reattaching the video.
* Ad playback, skipping now is working in Chrome.

### Testing
* Ad playback, skipping now is working in Chrome.

### Commit Message Subject
CTV-3207: Ability to skip demo ad in Reference App

### Additional Context

### Related PRs
n/a

### Checks
- [ ] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
