### PR TITLE
migrate to fastly CDN purging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## v1.7.2
+migrate to fastly CDN for ctv.truex.com
+
 ## v1.7.1
 * set cache-control header on all uploaded files
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -4,12 +4,12 @@ This document describes the initial steps needed to make use of the `TruexAdRend
 
 The true[X] ad renderer is available as an `npm` module. For the typical web app based around a `package.json` project file, one adds the true[X] dependency as follows:
 ```sh
-npm add @truex/ctv-ad-renderer
+npm add @truex/ad-renderer
 ```
 this will add an entry in the `"dependencies"` section in the `package.json` file, something like:
 ```json
     "dependencies": {
-        "@truex/ctv-ad-renderer": "1.0.0",
+        "@truex/ad-renderer": "1.12.5",
 ```
 One then builds and runs their web app like usual, e.g. invoking `npm start` for webpack-based projects.
 
@@ -17,7 +17,7 @@ One typically develops web apps in a local browser like Chrome, e.g. referring t
 
 To actually integrate the true[X] ad renderer, one has to create and invoke it during your app's video playback when the time of an ad break is reached. The pattern will look something like:
 ```javascript
-import { TruexAdRenderer } from '@truex/ctv-ad-renderer';
+import { TruexAdRenderer } from '@truex/ad-renderer';
 
 ...
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1063,32 +1063,19 @@
                 }
             }
         },
-        "@truex/ctv-ad-renderer": {
-            "version": "1.7.13",
-            "resolved": "https://registry.npmjs.org/@truex/ctv-ad-renderer/-/ctv-ad-renderer-1.7.13.tgz",
-            "integrity": "sha512-oGeTRhCLL3ioSOEWnvpDK3MLDFP6Xx937jSUgv5vCPad5N3BcHqxiPD7O2719aw0Hoj0o9R87kOJcPKcyhHhgg==",
+        "@truex/ad-renderer": {
+            "version": "1.12.5",
+            "resolved": "https://registry.npmjs.org/@truex/ad-renderer/-/ad-renderer-1.12.5.tgz",
+            "integrity": "sha512-u9k0PnRz/zMRIn43RCsEKhhlDOeBV1WqdNv1KS8AGdMWH24GAwstwP+tc0G1kr3DL8evlsOzBJO4SwZWzGhTMw==",
             "requires": {
                 "bluebird": "^3.5.1",
                 "centralize-js": "^1.1.4",
                 "core-js": "^3.6.4",
                 "lodash.merge": "^4.6.2",
                 "raven-js": "^3.25.2",
-                "truex-shared": "git+https://github.com/socialvibe/truex-shared-js.git#1.7.10",
+                "truex-shared": "git+https://github.com/socialvibe/truex-shared-js.git#1.10.3",
                 "uuid": "^3.4.0",
                 "whatwg-fetch": "^3.0.0"
-            },
-            "dependencies": {
-                "truex-shared": {
-                    "version": "git+https://github.com/socialvibe/truex-shared-js.git#abd1298728e43d46d1032c063235d5c4302a2ea9",
-                    "from": "git+https://github.com/socialvibe/truex-shared-js.git#1.7.10",
-                    "requires": {
-                        "aws-sdk": "^2.260.1",
-                        "edgecast-purge": "^0.1.1",
-                        "node-fetch": "^2.6.1",
-                        "uuid": "^3.4.0",
-                        "whatwg-fetch": "^3.0.0"
-                    }
-                }
             }
         },
         "@types/json-schema": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "TruexRefApp_GoogleIMA_DAI",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -4850,15 +4850,6 @@
             "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
             "dev": true
         },
-        "invalidate-cloudfront-edge-cache": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/invalidate-cloudfront-edge-cache/-/invalidate-cloudfront-edge-cache-1.1.0.tgz",
-            "integrity": "sha512-z6kCRw6NfO+xlwNoWCbK1bXG2QxsLCXOvJRnb1x1Wyk++iZQhb6ZsQjr3BLylWsm9DyMJoEEegnaJuXeowqtZg==",
-            "dev": true,
-            "requires": {
-                "aws-sdk": "^2.749.0"
-            }
-        },
         "is-accessor-descriptor": {
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -8442,8 +8433,8 @@
             }
         },
         "truex-shared": {
-            "version": "git+https://github.com/socialvibe/truex-shared-js.git#3e4fa5cba2d8788be251833ad382e972b9b864f9",
-            "from": "git+https://github.com/socialvibe/truex-shared-js.git#1.7.18",
+            "version": "git+https://github.com/socialvibe/truex-shared-js.git#e760615ff4142e5c7ff6b4845ec8f64085fc2e5b",
+            "from": "git+https://github.com/socialvibe/truex-shared-js.git#1.10.3",
             "requires": {
                 "aws-sdk": "^2.260.1",
                 "edgecast-purge": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "webpack-serve": "^1.0.4"
     },
     "dependencies": {
-        "@truex/ctv-ad-renderer": "1.7.13",
+        "@truex/ad-renderer": "1.12.5",
         "adm-zip": "^0.5.1",
         "core-js": "^3.6.4",
         "truex-shared": "https://github.com/socialvibe/truex-shared-js.git#1.10.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "TruexRefApp_GoogleIMA_DAI",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "description": "Sample app to demonstrate how to integrate Google IMA with true[X]'s CTV Web ad renderer",
     "main": "index.js",
     "public": true,
@@ -36,7 +36,6 @@
         "file-loader": "^6.0.0",
         "html-loader": "^1.1.0",
         "html-webpack-plugin": "^3.2.0",
-        "invalidate-cloudfront-edge-cache": "^1.1.0",
         "node-sass": "^4.14.1",
         "promise-to-upload-dist": "^0.0.7",
         "properties-reader": "^2.0.0",
@@ -52,7 +51,7 @@
         "@truex/ctv-ad-renderer": "1.7.13",
         "adm-zip": "^0.5.1",
         "core-js": "^3.6.4",
-        "truex-shared": "https://github.com/socialvibe/truex-shared-js.git#1.7.18",
+        "truex-shared": "https://github.com/socialvibe/truex-shared-js.git#1.10.3",
         "uuid": "^3.4.0",
         "whatwg-fetch": "^3.0.0"
     }

--- a/src/components/interactive-ad.js
+++ b/src/components/interactive-ad.js
@@ -1,5 +1,5 @@
 import uuid from 'uuid';
-import { TruexAdRenderer } from '@truex/ctv-ad-renderer';
+import { TruexAdRenderer } from '@truex/ad-renderer';
 
 // Exercises the True[X] Ad Renderer for interactive ads.
 export class InteractiveAd {

--- a/src/components/video-controller.js
+++ b/src/components/video-controller.js
@@ -156,7 +156,6 @@ export class VideoController {
         this.streamManager.addEventListener(streamEvents, this.onStreamEvent, false);
 
         const streamRequest = new google.ima.dai.api.VODStreamRequest();
-        streamRequest.assetKey
         streamRequest.contentSourceId = videoStream.google_content_id;
         streamRequest.videoId = videoStream.google_video_id;
         streamRequest.apiKey = null; // unused since stream is not encrypted

--- a/src/components/video-controller.js
+++ b/src/components/video-controller.js
@@ -156,6 +156,7 @@ export class VideoController {
         this.streamManager.addEventListener(streamEvents, this.onStreamEvent, false);
 
         const streamRequest = new google.ima.dai.api.VODStreamRequest();
+        streamRequest.assetKey
         streamRequest.contentSourceId = videoStream.google_content_id;
         streamRequest.videoId = videoStream.google_video_id;
         streamRequest.apiKey = null; // unused since stream is not encrypted

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,7 @@ import { inputActions } from 'truex-shared/focus_manager/txm_input_actions';
 import { Focusable } from 'truex-shared/focus_manager/txm_focusable';
 import { TXMFocusManager } from 'truex-shared/focus_manager/txm_focus_manager';
 import { ScriptLoader } from "truex-shared/utils/loaders";
-import { TruexAdRenderer } from '@truex/ctv-ad-renderer';
+import { TruexAdRenderer } from '@truex/ad-renderer';
 import { LoadingSpinner } from "./components/loading-spinner";
 import { VideoController } from "./components/video-controller";
 import homeBackgroundPath from "./assets/home-page-background.png";

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -8,18 +8,17 @@ const { purgeFastlyService }  = require("truex-shared/src/deploy/purge-fastly-se
 
 const deploy = () => {
     const bucket = "ctv.truex.com";
-    // const branch = process.env.TRAVIS_BRANCH;
-    const branch = 'test';
+    const branch = process.env.TRAVIS_BRANCH;
     const prefix = 'web/ref-app-google-IMA/' + branch;
 
     const PR = process.env.TRAVIS_PULL_REQUEST;
     const isPR = PR != "false";
 
-    // if (isPR) {
-    //     // We only want to deploy on the final merges.
-    //     console.log(`PR deploy skipped for ${bucket}/${prefix}`);
-    //     process.exit(0);
-    // }
+    if (isPR) {
+        // We only want to deploy on the final merges.
+        console.log(`PR deploy skipped for ${bucket}/${prefix}`);
+        process.exit(0);
+    }
 
     console.log(`deploying to ${bucket}/${prefix}`);
     // Note: ensure trailing / so that only the branch folder is deleted.

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -4,22 +4,22 @@ require('truex-shared/src/deploy/promisify').polyfill();
 
 const s3 = require('truex-shared/src/deploy/s3-upload');
 const uploadDist = require('truex-shared/src/deploy/upload-dist');
-const awsCloudFrontInvalidate = require("invalidate-cloudfront-edge-cache");
+const { purgeFastlyService }  = require("truex-shared/src/deploy/purge-fastly-service");
 
 const deploy = () => {
     const bucket = "ctv.truex.com";
-    const branch = process.env.TRAVIS_BRANCH;
+    // const branch = process.env.TRAVIS_BRANCH;
+    const branch = 'test';
     const prefix = 'web/ref-app-google-IMA/' + branch;
 
     const PR = process.env.TRAVIS_PULL_REQUEST;
     const isPR = PR != "false";
-    const cloudFrontDistId = process.env.TRUEX_CLOUDFRONT_DISTRIBUTION_ID;
 
-    if (isPR) {
-        // We only want to deploy on the final merges.
-        console.log(`PR deploy skipped for ${bucket}/${prefix}`);
-        process.exit(0);
-    }
+    // if (isPR) {
+    //     // We only want to deploy on the final merges.
+    //     console.log(`PR deploy skipped for ${bucket}/${prefix}`);
+    //     process.exit(0);
+    // }
 
     console.log(`deploying to ${bucket}/${prefix}`);
     // Note: ensure trailing / so that only the branch folder is deleted.
@@ -30,9 +30,9 @@ const deploy = () => {
             return uploadDist(bucket, prefix);
         })
         .then(() => {
-            console.log("invalidating cloudfront cache");
-            const pathsToInvalidate = [`/${prefix}/index.html`];
-            return awsCloudFrontInvalidate(cloudFrontDistId, pathsToInvalidate);
+            // Purge the entire Fastly CDN service for robustness, it is ok performance-wise.
+            // Fastly otherwise makes it difficult to purge related urls, e.g. .../someFile.js vs .../someFile.js?cb=460
+            return purgeFastlyService(bucket, process.env.FASTLY_API_TOKEN);
         })
         .then(() => {
             console.log("deploy complete");


### PR DESCRIPTION
JIRA: [PI-2310](https://infillion.atlassian.net/browse/PI-2310): Migrate deployment scripts from Cloudfront to Fastly CDN caches

Deploy now invokes fastly cache invalidation instead of Cloudfront's.

Test by pushing PRs, merging to develop, merging to master.

TODO: merge only once new fastly-based ctv.truex.com is public


[PI-2310]: https://infillion.atlassian.net/browse/PI-2310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ